### PR TITLE
Refactor/equals and hash code

### DIFF
--- a/Hestia/app/src/androidTest/java/com/rugged/application/hestia/backend/NetworkHandlerTest.java
+++ b/Hestia/app/src/androidTest/java/com/rugged/application/hestia/backend/NetworkHandlerTest.java
@@ -79,10 +79,11 @@ public class NetworkHandlerTest {
     }
 
     @Test
-    public void equalsSamePropertiesTest() {
+    public void equalsAndHashCodeSamePropertiesTest() {
         NetworkHandler handlerSameProperties = new NetworkHandler(dummyIP, dummyPort);
         assertNotNull(handlerSameProperties);
         assertTrue(dummyHandler.equals(handlerSameProperties));
+        assertEquals(dummyHandler.hashCode(), handlerSameProperties.hashCode());
     }
 
     @Test
@@ -93,12 +94,13 @@ public class NetworkHandlerTest {
     }
 
     @Test
-    public void equalsDifferentPropertiesTest() {
+    public void equalsAndHashCodeDifferentPropertiesTest() {
         String IP = "1.1.1.1";
         Integer port = 2000;
         NetworkHandler handlerDifferentProperties = new NetworkHandler(IP, port);
         assertNotNull(handlerDifferentProperties);
         assertFalse(dummyHandler.equals(handlerDifferentProperties));
+        assertNotSame(dummyHandler.hashCode(), handlerDifferentProperties.hashCode());
     }
 
     @After

--- a/Hestia/app/src/androidTest/java/com/rugged/application/hestia/backend/models/ActivatorStateTest.java
+++ b/Hestia/app/src/androidTest/java/com/rugged/application/hestia/backend/models/ActivatorStateTest.java
@@ -9,10 +9,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import hestia.backend.models.ActivatorState;
 import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 
 @RunWith(AndroidJUnit4.class)
 public class ActivatorStateTest {
@@ -126,33 +128,75 @@ public class ActivatorStateTest {
     }
 
     /**
-     * equals() method tests.
+     * equals() and hashCode() methods tests.
      */
     @Test
-    public void boolActivatorEqualsTest() {
+    public void equalsAndHashCodeBoolActivatorStateSamePropertiesTest() {
         ActivatorState<Boolean> newBoolActivatorState = new ActivatorState<>(DEFAULT_BOOL_RAW_STATE, DEFAULT_BOOL_TYPE);
         assertNotNull(newBoolActivatorState);
         assertTrue(newBoolActivatorState.equals(boolActivatorState));
         assertFalse(newBoolActivatorState.equals(stringActivatorState));
         assertFalse(newBoolActivatorState.equals(floatActivatorState));
+        assertEquals(newBoolActivatorState.hashCode(), boolActivatorState.hashCode());
     }
 
     @Test
-    public void floatActivatorEqualsTest() {
+    public void equalsAndHashCodeFloatActivatorStateSamePropertiesTest() {
         ActivatorState<Float> newFloatActivatorState = new ActivatorState<>(DEFAULT_FLOAT_RAW_STATE, DEFAULT_FLOAT_TYPE);
         assertNotNull(newFloatActivatorState);
         assertTrue(newFloatActivatorState.equals(floatActivatorState));
         assertFalse(newFloatActivatorState.equals(boolActivatorState));
         assertFalse(newFloatActivatorState.equals(stringActivatorState));
+        assertEquals(newFloatActivatorState.hashCode(), floatActivatorState.hashCode());
     }
 
     @Test
-    public void stringActivatorEqualsTest() {
+    public void equalsAndHashCodeStringActivatorStateSamePropertiesTest() {
         ActivatorState<String> newStringActivatorState = new ActivatorState<>(DEFAULT_STRING_RAW_STATE, DEFAULT_STRING_TYPE);
         assertNotNull(newStringActivatorState);
         assertTrue(newStringActivatorState.equals(stringActivatorState));
         assertFalse(newStringActivatorState.equals(boolActivatorState));
         assertFalse(newStringActivatorState.equals(floatActivatorState));
+        assertEquals(newStringActivatorState.hashCode(), stringActivatorState.hashCode());
+    }
+
+    @Test
+    public void equalsNullTest() {
+        ActivatorState activatorStateNull = null;
+        assertNull(activatorStateNull);
+        assertFalse(boolActivatorState.equals(activatorStateNull));
+        assertFalse(floatActivatorState.equals(activatorStateNull));
+        assertFalse(stringActivatorState.equals(activatorStateNull));
+    }
+
+    @Test
+    public void equalsAndHashCodeBoolActivatorStateDifferentPropertiesTest() {
+        String newBoolType = "bool";
+        Boolean newRawValue = true;
+        ActivatorState<Boolean> differentBoolActivatorState = new ActivatorState<>(newRawValue, newBoolType);
+        assertNotNull(differentBoolActivatorState);
+        assertFalse(boolActivatorState.equals(differentBoolActivatorState));
+        assertNotSame(boolActivatorState.hashCode(), differentBoolActivatorState.hashCode());
+    }
+
+    @Test
+    public void equalsAndHashCodeFloatActivatorStateDifferentPropertiesTest() {
+        String newBoolType = "float";
+        Float newRawValue = 5.9f;
+        ActivatorState<Float> differentFloatActivatorState = new ActivatorState<>(newRawValue, newBoolType);
+        assertNotNull(differentFloatActivatorState);
+        assertFalse(floatActivatorState.equals(differentFloatActivatorState));
+        assertNotSame(floatActivatorState.hashCode(), differentFloatActivatorState.hashCode());
+    }
+
+    @Test
+    public void equalsAndHashCodeStringActivatorStateDifferentPropertiesTest() {
+        String newBoolType = "string";
+        String newRawValue = "newRawValueRandomString";
+        ActivatorState<String> differentStringActivatorState = new ActivatorState<>(newRawValue, newBoolType);
+        assertNotNull(differentStringActivatorState);
+        assertFalse(stringActivatorState.equals(differentStringActivatorState));
+        assertNotSame(stringActivatorState.hashCode(), differentStringActivatorState.hashCode());
     }
 
     /**

--- a/Hestia/app/src/androidTest/java/com/rugged/application/hestia/backend/models/DeviceTest.java
+++ b/Hestia/app/src/androidTest/java/com/rugged/application/hestia/backend/models/DeviceTest.java
@@ -17,6 +17,9 @@ import hestia.backend.models.ActivatorState;
 import hestia.backend.models.Device;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNotSame;
+import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -164,10 +167,30 @@ public class DeviceTest {
     }
 
     @Test
-    public void equalsTest() {
-        // create a new Device object with the same data as the deviceTest object
-        Device dummyDevice = new Device(DEFAULT_DEVICE_ID, DEFAULT_DEVICE_NAME, DEFAULT_DEVICE_TYPE,activators, handler);
-        assertTrue(dummyDevice.equals(deviceTest));
-        assertEquals(dummyDevice, deviceTest);
+    public void equalsAndHashCodeSamePropertiesTest() {
+        Device deviceSameProperties = new Device(DEFAULT_DEVICE_ID, DEFAULT_DEVICE_NAME, DEFAULT_DEVICE_TYPE,activators, handler);
+        assertTrue(deviceSameProperties.equals(deviceTest));
+        assertEquals(deviceSameProperties, deviceTest);
+        assertEquals(deviceSameProperties.hashCode(), deviceTest.hashCode());
+    }
+
+    @Test
+    public void equalsNullTest() {
+        Device deviceNull = null;
+        assertNull(deviceNull);
+        assertFalse(deviceTest.equals(deviceNull));
+    }
+
+    @Test
+    public void equalsAndHashCodeDifferentPropertiesTest() {
+        String newId = "newDeviceId";
+        String newName = "newDeviceName";
+        String newType = "newDeviceType";
+        ArrayList<Activator> newActivators = new ArrayList<>();
+        NetworkHandler newHandler = new NetworkHandler("newIp", 5050);
+        Device deviceDifferentProperties = new Device(newId, newName, newType, newActivators, newHandler);
+        assertNotNull(deviceDifferentProperties);
+        assertFalse(deviceTest.equals(deviceDifferentProperties));
+        assertNotSame(deviceTest.hashCode(), deviceDifferentProperties.hashCode());
     }
 }

--- a/Hestia/app/src/androidTest/java/com/rugged/application/hestia/backend/models/DeviceTest.java
+++ b/Hestia/app/src/androidTest/java/com/rugged/application/hestia/backend/models/DeviceTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.when;
 @RunWith(AndroidJUnit4.class)
 public class DeviceTest {
     private Device deviceTest;
+    private Activator dummyActivator;
     private ArrayList<Activator> activators;
     private NetworkHandler handler;
     private final String DEFAULT_DEVICE_ID = "12";
@@ -37,16 +38,19 @@ public class DeviceTest {
 
     @Before
     public void createDevice(){
-        ActivatorState<Boolean> testState = new ActivatorState<>(false,"bool");
-        Activator testButton = new Activator("0",0,testState,"testButton");
+        ActivatorState<Boolean> testState = new ActivatorState<>(false, "bool");
+        dummyActivator = new Activator("0", 0, testState, "testButton");
         activators = new ArrayList<>();
-        activators.add(testButton);
+        activators.add(dummyActivator);
 
         String defaultIp = "127.0.0.1";
         Integer defaultPort = 1000;
         handler = new NetworkHandler(defaultIp, defaultPort);
 
-        deviceTest = new Device(DEFAULT_DEVICE_ID,DEFAULT_DEVICE_NAME,DEFAULT_DEVICE_TYPE,activators, handler);
+        deviceTest = new Device(DEFAULT_DEVICE_ID, DEFAULT_DEVICE_NAME, DEFAULT_DEVICE_TYPE,
+                                activators, handler);
+        dummyActivator.setDevice(deviceTest);
+        dummyActivator.setHandler(handler);
     }
 
     @Test

--- a/Hestia/app/src/main/java/hestia/UI/dialogs/ChangeIpDialog.java
+++ b/Hestia/app/src/main/java/hestia/UI/dialogs/ChangeIpDialog.java
@@ -1,18 +1,12 @@
 package hestia.UI.dialogs;
 
-import android.app.AlertDialog;
-import android.app.Dialog;
-import android.content.DialogInterface;
 import android.content.res.Configuration;
-import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
-import android.view.WindowManager;
 import android.widget.EditText;
 import android.widget.Toast;
 import com.rugged.application.hestia.R;
-
 import hestia.backend.ServerCollectionsInteractor;
 
 /**
@@ -24,7 +18,6 @@ public class ChangeIpDialog extends HestiaDialog {
     private final static String TAG = "ChangeIpDialog";
     private String ip;
     private EditText ipField;
-
     private ServerCollectionsInteractor serverCollectionsInteractor;
 
     public static ChangeIpDialog newInstance() {

--- a/Hestia/app/src/main/java/hestia/UI/elements/DeviceBar.java
+++ b/Hestia/app/src/main/java/hestia/UI/elements/DeviceBar.java
@@ -18,7 +18,6 @@ import com.rugged.application.hestia.R;
 
 import java.io.IOException;
 
-import hestia.UI.HestiaApplication;
 import hestia.UI.dialogs.ChangeNameDialog;
 import hestia.UI.dialogs.SlidersDialog;
 import hestia.backend.ServerCollectionsInteractor;
@@ -29,7 +28,7 @@ import hestia.backend.models.Device;
 
 /**
  *  This class takes care of the deviceBar.
- * The devicebar is the 'row' in the expandable list of a single device.
+ * The DeviceBar is the 'row' in the expandable list of a single device.
  */
 
 public class DeviceBar extends RelativeLayout {
@@ -201,15 +200,6 @@ public class DeviceBar extends RelativeLayout {
 
     @Override
     public boolean equals(Object object) {
-//        boolean equal = false;
-//
-//        if (object != null && object instanceof DeviceBar) {
-//            if(this.device.getId().equals(((DeviceBar) object).getDevice().getId())) {
-//                equal = true;
-//            }
-//        }
-//        return equal;
-
         if(!(object instanceof DeviceBar)) return false;
         DeviceBar deviceBar = (DeviceBar) object;
         return (this == deviceBar || (this.getDevice().equals(deviceBar.getDevice())));
@@ -217,7 +207,6 @@ public class DeviceBar extends RelativeLayout {
 
     @Override
     public int hashCode() {
-        int multiplier = Integer.valueOf(HestiaApplication.getContext().getString(R.string.hashCodeMultiplier));
         int result = getDevice().hashCode();
         return result;
     }

--- a/Hestia/app/src/main/java/hestia/UI/elements/DeviceBar.java
+++ b/Hestia/app/src/main/java/hestia/UI/elements/DeviceBar.java
@@ -13,8 +13,12 @@ import android.widget.RelativeLayout;
 import android.widget.Switch;
 import android.widget.TextView;
 import android.widget.Toast;
+
 import com.rugged.application.hestia.R;
+
 import java.io.IOException;
+
+import hestia.UI.HestiaApplication;
 import hestia.UI.dialogs.ChangeNameDialog;
 import hestia.UI.dialogs.SlidersDialog;
 import hestia.backend.ServerCollectionsInteractor;
@@ -58,7 +62,8 @@ public class DeviceBar extends RelativeLayout {
         switc.setVisibility(View.INVISIBLE);
 
         for(final Activator activator : device.getActivators()){
-            if(activator.getRank() == 0){
+            int toggleRank = Integer.valueOf(context.getResources().getString(R.string.toggleRank));
+            if(activator.getRank() == toggleRank) {
                 if(activator.getState().getType().equals("bool")){
                     switc.setEnabled(true);
                     switc.setVisibility(View.VISIBLE);
@@ -79,7 +84,7 @@ public class DeviceBar extends RelativeLayout {
         if(deviceHasSlider()) {
             this.setOnClickListener(new View.OnClickListener() {
                 @Override
-                public void onClick(View v) {
+                public void onClick(View view) {
                     new SlidersDialog(getContext(), device).show();
                 }
             });
@@ -101,9 +106,7 @@ public class DeviceBar extends RelativeLayout {
                             case R.id.change_name:
                                 ChangeNameDialog fragment = ChangeNameDialog.newInstance();
                                 fragment.setDevice(device);
-
                                 fragment.show(fm, "dialog");
-
                                 break;
                             default:
                                 break;
@@ -136,18 +139,6 @@ public class DeviceBar extends RelativeLayout {
 
     public void setDevice(Device device) {
         this.device = device;
-    }
-
-    @Override
-    public boolean equals(Object object) {
-        boolean equal = false;
-
-        if (object != null && object instanceof DeviceBar) {
-            if(this.device.getId() == ((DeviceBar) object).getDevice().getId()){
-                equal = true;
-            }
-        }
-        return equal;
     }
 
     private void checked(final ActivatorState<Boolean> state, final Activator activator) {
@@ -206,5 +197,28 @@ public class DeviceBar extends RelativeLayout {
                 Toast.makeText(context, exceptionMessage[0], Toast.LENGTH_SHORT).show();
             }
         }.execute();
+    }
+
+    @Override
+    public boolean equals(Object object) {
+//        boolean equal = false;
+//
+//        if (object != null && object instanceof DeviceBar) {
+//            if(this.device.getId().equals(((DeviceBar) object).getDevice().getId())) {
+//                equal = true;
+//            }
+//        }
+//        return equal;
+
+        if(!(object instanceof DeviceBar)) return false;
+        DeviceBar deviceBar = (DeviceBar) object;
+        return (this == deviceBar || (this.getDevice().equals(deviceBar.getDevice())));
+    }
+
+    @Override
+    public int hashCode() {
+        int multiplier = Integer.valueOf(HestiaApplication.getContext().getString(R.string.hashCodeMultiplier));
+        int result = getDevice().hashCode();
+        return result;
     }
 }

--- a/Hestia/app/src/main/java/hestia/backend/NetworkHandler.java
+++ b/Hestia/app/src/main/java/hestia/backend/NetworkHandler.java
@@ -2,15 +2,13 @@ package hestia.backend;
 
 import android.app.Application;
 import android.util.Log;
-
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
-
+import com.rugged.application.hestia.R;
 import org.apache.http.conn.ssl.AllowAllHostnameVerifier;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -19,7 +17,6 @@ import java.lang.reflect.Type;
 import java.net.URL;
 import java.security.GeneralSecurityException;
 import java.security.cert.X509Certificate;
-
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
@@ -169,12 +166,17 @@ public class NetworkHandler extends Application {
 
     @Override
     public boolean equals(Object object) {
-        if (this == object) return true;
-        if (!(object instanceof NetworkHandler)) return false;
-
+        if(!(object instanceof NetworkHandler)) return false;
         NetworkHandler networkHandler = (NetworkHandler) object;
-        if (!this.getPort().equals(networkHandler.getPort())) return false;
-        return this.getIp().equals(networkHandler.getIp());
+        return (this == networkHandler || (this.getPort().equals(networkHandler.getPort()) &&
+                                           this.getIp().equals(networkHandler.getIp())));
+    }
+
+    @Override
+    public int hashCode() {
+        int multiplier = Integer.valueOf(getResources().getString(R.string.hashCodeMultiplier));
+        int result = getIp().hashCode() * multiplier + getPort().hashCode();
+        return result;
     }
 
     /**

--- a/Hestia/app/src/main/java/hestia/backend/NetworkHandler.java
+++ b/Hestia/app/src/main/java/hestia/backend/NetworkHandler.java
@@ -170,21 +170,6 @@ public class NetworkHandler extends Application {
         return "https://" + ip + ":" + port + "/";
     }
 
-    @Override
-    public boolean equals(Object object) {
-        if(!(object instanceof NetworkHandler)) return false;
-        NetworkHandler networkHandler = (NetworkHandler) object;
-        return (this == networkHandler || (this.getPort().equals(networkHandler.getPort()) &&
-                                           this.getIp().equals(networkHandler.getIp())));
-    }
-
-    @Override
-    public int hashCode() {
-        int multiplier = Integer.valueOf(HestiaApplication.getContext().getString(R.string.hashCodeMultiplier));
-        int result = getIp().hashCode() * multiplier + getPort().hashCode();
-        return result;
-    }
-
     /**
      * This code creates a socketFactory which trusts all certificates. <b>WARNING</b> this cannot
      * be used in production code as it leaves the app vulnerable to MITM attacks.
@@ -219,4 +204,18 @@ public class NetworkHandler extends Application {
         }
     }
 
+    @Override
+    public boolean equals(Object object) {
+        if(!(object instanceof NetworkHandler)) return false;
+        NetworkHandler networkHandler = (NetworkHandler) object;
+        return (this == networkHandler || (this.getPort().equals(networkHandler.getPort()) &&
+                                           this.getIp().equals(networkHandler.getIp())));
+    }
+
+    @Override
+    public int hashCode() {
+        int multiplier = Integer.valueOf(HestiaApplication.getContext().getString(R.string.hashCodeMultiplier));
+        int result = getIp().hashCode() * multiplier + getPort().hashCode();
+        return result;
+    }
 }

--- a/Hestia/app/src/main/java/hestia/backend/NetworkHandler.java
+++ b/Hestia/app/src/main/java/hestia/backend/NetworkHandler.java
@@ -2,13 +2,16 @@ package hestia.backend;
 
 import android.app.Application;
 import android.util.Log;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 import com.rugged.application.hestia.R;
+
 import org.apache.http.conn.ssl.AllowAllHostnameVerifier;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -17,10 +20,13 @@ import java.lang.reflect.Type;
 import java.net.URL;
 import java.security.GeneralSecurityException;
 import java.security.cert.X509Certificate;
+
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
+
+import hestia.UI.HestiaApplication;
 
 
 /**
@@ -174,7 +180,7 @@ public class NetworkHandler extends Application {
 
     @Override
     public int hashCode() {
-        int multiplier = Integer.valueOf(getResources().getString(R.string.hashCodeMultiplier));
+        int multiplier = Integer.valueOf(HestiaApplication.getContext().getString(R.string.hashCodeMultiplier));
         int result = getIp().hashCode() * multiplier + getPort().hashCode();
         return result;
     }

--- a/Hestia/app/src/main/java/hestia/backend/ServerCollectionsInteractor.java
+++ b/Hestia/app/src/main/java/hestia/backend/ServerCollectionsInteractor.java
@@ -6,9 +6,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
-
-import org.json.JSONObject;
-
 import java.io.IOException;
 import java.io.Serializable;
 import java.lang.reflect.Type;

--- a/Hestia/app/src/main/java/hestia/backend/models/Activator.java
+++ b/Hestia/app/src/main/java/hestia/backend/models/Activator.java
@@ -2,9 +2,11 @@ package hestia.backend.models;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.rugged.application.hestia.R;
 
 import java.io.IOException;
 
+import hestia.UI.HestiaApplication;
 import hestia.backend.NetworkHandler;
 import hestia.backend.exceptions.ComFaultException;
 
@@ -31,15 +33,6 @@ public class Activator {
         this.rank = rank;
         this.state = state;
         this.name = name;
-    }
-
-    public Activator(String activatorId, Integer rank, ActivatorState state, String name, Device device, NetworkHandler handler) {
-        this.activatorId = activatorId;
-        this.rank = rank;
-        this.state = state;
-        this.name = name;
-        this.device = device;
-        this.handler = handler;
     }
 
     public String getId() {
@@ -121,16 +114,25 @@ public class Activator {
 
     @Override
     public int hashCode() {
-        int result = activatorId.hashCode();
-        result = 31 * result + getRank().hashCode();
-        result = 31 * result + getState().hashCode();
-        result = 31 * result + getName().hashCode();
-        if(device != null){
-            result = 31 * result + device.hashCode();
-        }
-        if(handler != null){
-            result = 31 * result + getHandler().hashCode();
-        }
+//        int result = activatorId.hashCode();
+//        result = 31 * result + getRank().hashCode();
+//        result = 31 * result + getState().hashCode();
+//        result = 31 * result + getName().hashCode();
+//        if(device != null){
+//            result = 31 * result + device.hashCode();
+//        }
+//        if(handler != null){
+//            result = 31 * result + getHandler().hashCode();
+//        }
+//        return result;
+
+        int multiplier = Integer.valueOf(HestiaApplication.getContext().getString(R.string.hashCodeMultiplier));
+        int result = getId().hashCode();
+        result = result * multiplier + getRank().hashCode();
+        result = result * multiplier + getState().hashCode();
+        result = result * multiplier + getName().hashCode();
+        result = result * multiplier + getDevice().hashCode();
+        result = result * multiplier + getHandler().hashCode();
         return result;
     }
 

--- a/Hestia/app/src/main/java/hestia/backend/models/Activator.java
+++ b/Hestia/app/src/main/java/hestia/backend/models/Activator.java
@@ -98,40 +98,23 @@ public class Activator {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Activator)) return false;
-
-        Activator activator = (Activator) o;
-
-        if (!activatorId.equals(activator.activatorId)) return false;
-        if (!getRank().equals(activator.getRank())) return false;
-        if (!getState().equals(activator.getState())) return false;
-        if (!getName().equals(activator.getName())) return false;
-        if (!device.equals(activator.device)) return false;
-        return getHandler().equals(activator.getHandler());
+    public boolean equals(Object object) {
+        if(!(object instanceof Activator)) return false;
+        Activator activator = (Activator) object;
+        return (this == activator || (this.getId().equals(activator.getId()) &&
+                                      this.getRank().equals(activator.getRank()) &&
+                                      this.getState().equals(activator.getState()) &&
+                                      this.getName().equals(activator.getName()) &&
+                                      this.getHandler().equals(activator.getHandler())));
     }
 
     @Override
     public int hashCode() {
-//        int result = activatorId.hashCode();
-//        result = 31 * result + getRank().hashCode();
-//        result = 31 * result + getState().hashCode();
-//        result = 31 * result + getName().hashCode();
-//        if(device != null){
-//            result = 31 * result + device.hashCode();
-//        }
-//        if(handler != null){
-//            result = 31 * result + getHandler().hashCode();
-//        }
-//        return result;
-
         int multiplier = Integer.valueOf(HestiaApplication.getContext().getString(R.string.hashCodeMultiplier));
         int result = getId().hashCode();
         result = result * multiplier + getRank().hashCode();
         result = result * multiplier + getState().hashCode();
         result = result * multiplier + getName().hashCode();
-        result = result * multiplier + getDevice().hashCode();
         result = result * multiplier + getHandler().hashCode();
         return result;
     }

--- a/Hestia/app/src/main/java/hestia/backend/models/ActivatorState.java
+++ b/Hestia/app/src/main/java/hestia/backend/models/ActivatorState.java
@@ -1,6 +1,9 @@
 package hestia.backend.models;
 
 import com.google.gson.JsonPrimitive;
+import com.rugged.application.hestia.R;
+
+import hestia.UI.HestiaApplication;
 import hestia.backend.models.deserializers.ActivatorDeserializer;
 
 /**
@@ -75,21 +78,18 @@ public class ActivatorState<T> {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ActivatorState)) return false;
-
-        ActivatorState<?> that = (ActivatorState<?>) o;
-
-        if (!getRawState().equals(that.getRawState())) return false;
-        return getType().equals(that.getType());
+    public boolean equals(Object object) {
+        if(!(object instanceof ActivatorState)) return false;
+        ActivatorState activatorState = (ActivatorState) object;
+        return (this == activatorState || (this.getType().equals(activatorState.getType()) &&
+                                           this.getRawState().equals(activatorState.getRawState())));
 
     }
 
     @Override
     public int hashCode() {
-        int result = getRawState().hashCode();
-        result = 31 * result + getType().hashCode();
+        int multiplier = Integer.valueOf(HestiaApplication.getContext().getString(R.string.hashCodeMultiplier));
+        int result = getRawState().hashCode() * multiplier + getType().hashCode();
         return result;
     }
 }

--- a/Hestia/app/src/main/java/hestia/backend/models/Device.java
+++ b/Hestia/app/src/main/java/hestia/backend/models/Device.java
@@ -4,8 +4,12 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.rugged.application.hestia.R;
+
 import java.io.IOException;
 import java.util.ArrayList;
+
+import hestia.UI.HestiaApplication;
 import hestia.backend.exceptions.ComFaultException;
 import hestia.backend.NetworkHandler;
 
@@ -95,27 +99,25 @@ public class Device {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Device)) return false;
-
-        Device device = (Device) o;
-
-        if (!getId().equals(device.getId())) return false;
-        if (!getName().equals(device.getName())) return false;
-        if (!getType().equals(device.getType())) return false;
-        if (!getActivators().equals(device.getActivators())) return false;
-        return getHandler().equals(device.getHandler());
+    public boolean equals(Object object) {
+        if(!(object instanceof Device)) return false;
+        Device device = (Device) object;
+        return (this == device || (this.getId().equals(device.getId()) &&
+                                   this.getName().equals(device.getName()) &&
+                                   this.getType().equals(device.getType()) &&
+                                   this.getActivators().equals(device.getActivators()) &&
+                                   this.getHandler().equals(device.getHandler())));
 
     }
 
     @Override
     public int hashCode() {
+        int multiplier = Integer.valueOf(HestiaApplication.getContext().getString(R.string.hashCodeMultiplier));
         int result = getId().hashCode();
-        result = 31 * result + getName().hashCode();
-        result = 31 * result + getType().hashCode();
-        result = 31 * result + getActivators().hashCode();
-        result = 31 * result + getHandler().hashCode();
+        result = result * multiplier + getName().hashCode();
+        result = result * multiplier + getType().hashCode();
+        result = result * multiplier + getActivators().hashCode();
+        result = result * multiplier + getHandler().hashCode();
         return result;
     }
 

--- a/Hestia/app/src/main/res/values/strings.xml
+++ b/Hestia/app/src/main/res/values/strings.xml
@@ -50,4 +50,5 @@
     <string name="userSet">Username set to: </string>
     <string name="userNotSet">Username not changed (length under 5)</string>
     <string name="hashCodeMultiplier">31</string>
+    <string name="toggleRank">0</string>
 </resources>

--- a/Hestia/app/src/main/res/values/strings.xml
+++ b/Hestia/app/src/main/res/values/strings.xml
@@ -49,4 +49,5 @@
     <string name="passSet">Password set to: </string>
     <string name="userSet">Username set to: </string>
     <string name="userNotSet">Username not changed (length under 5)</string>
+    <string name="hashCodeMultiplier">31</string>
 </resources>


### PR DESCRIPTION
Updated equals() and hashCode() methods of the following classes:
- Activator
- ActivatorState
- Device
- NetworkHandler
- DeviceBar

Refactor Activator state: previously, it used 2 constructors. One of them was the one used throughout the program and the other one was used only for testing purposes. I deleted the second one.

Updated all tests so that they check both equals() and hashCode() methods with 3 types of objects:
- one which has the same properties, so the assertions should prove that they are equal;
- one which is null, so the assertion should be false;
- one which has different properties, so the assertion should be false again.